### PR TITLE
Add OrderItems entity and update Order with list of OrderItems

### DIFF
--- a/src/main/kotlin/com/nickdferrara/retailstore/orders/domain/Order.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/orders/domain/Order.kt
@@ -12,5 +12,9 @@ data class Order(
     val orderNumber: String,
     val orderDate: LocalDate,
     val status: String,
-    val totalAmount: BigDecimal
+    val totalAmount: BigDecimal,
+
+    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true)
+    @JoinColumn(name = "order_id")
+    val orderItems: List<OrderItem>
 )

--- a/src/main/kotlin/com/nickdferrara/retailstore/orders/domain/OrderItem.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/orders/domain/OrderItem.kt
@@ -1,0 +1,15 @@
+package com.nickdferrara.retailstore.orders.domain
+
+import jakarta.persistence.*
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "order_items")
+data class OrderItem(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    val name: String,
+    val brand: String,
+    val quantity: Int,
+    val price: BigDecimal
+)

--- a/src/main/kotlin/com/nickdferrara/retailstore/orders/repository/OrderItemRepository.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/orders/repository/OrderItemRepository.kt
@@ -1,0 +1,8 @@
+package com.nickdferrara.retailstore.orders.repository
+
+import com.nickdferrara.retailstore.orders.domain.OrderItem
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface OrderItemRepository : JpaRepository<OrderItem, Long>

--- a/src/main/kotlin/com/nickdferrara/retailstore/orders/service/OrderService.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/orders/service/OrderService.kt
@@ -12,10 +12,14 @@ class OrderService(private val orderRepository: OrderRepository) {
 
     fun findOrderById(id: Long): Order? = orderRepository.findById(id).orElse(null)
 
-    fun createOrder(order: Order): Order = orderRepository.save(order)
+    fun createOrder(order: Order): Order {
+        order.orderItems.forEach { it.order = order }
+        return orderRepository.save(order)
+    }
 
     fun updateOrder(id: Long, order: Order): Order {
         return if (orderRepository.existsById(id)) {
+            order.orderItems.forEach { it.order = order }
             orderRepository.save(order.copy(id = id))
         } else {
             throw NoSuchElementException("Order with id $id not found")


### PR DESCRIPTION
Add OrderItems entity and update Order entity to include a list of OrderItems.

* **OrderItem Entity**: Create a new entity class `OrderItem` with fields `id`, `name`, `brand`, `quantity`, and `price`. Annotate the class with `@Entity` and `@Table(name = "order_items")`.
* **Order Entity**: Add a new field `orderItems` of type `List<OrderItem>` to the `Order` class. Annotate the `orderItems` field with `@OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true)` and `@JoinColumn(name = "order_id")`.
* **OrderItemRepository**: Create a new repository interface `OrderItemRepository` extending `JpaRepository<OrderItem, Long>`. Annotate the interface with `@Repository`.
* **OrderService**: Update the `createOrder` method to save `orderItems` along with the `Order`. Update the `updateOrder` method to save `orderItems` along with the `Order`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nickdferrara/Server-Springboot-Retail?shareId=03df9f3b-20d5-41cc-8e9e-cd788118f013).