### PR TITLE
Update order module to use OrderItemService

### DIFF
--- a/src/main/kotlin/com/nickdferrara/retailstore/orders/service/OrderItemService.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/orders/service/OrderItemService.kt
@@ -1,0 +1,32 @@
+package com.nickdferrara.retailstore.orders.service
+
+import com.nickdferrara.retailstore.orders.domain.OrderItem
+import com.nickdferrara.retailstore.orders.repository.OrderItemRepository
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class OrderItemService(private val orderItemRepository: OrderItemRepository) {
+
+    fun findAllOrderItems(): List<OrderItem> = orderItemRepository.findAll()
+
+    fun findOrderItemById(id: Long): OrderItem? = orderItemRepository.findById(id).orElse(null)
+
+    fun createOrderItem(orderItem: OrderItem): OrderItem = orderItemRepository.save(orderItem)
+
+    fun updateOrderItem(id: Long, orderItem: OrderItem): OrderItem {
+        return if (orderItemRepository.existsById(id)) {
+            orderItemRepository.save(orderItem.copy(id = id))
+        } else {
+            throw NoSuchElementException("OrderItem with id $id not found")
+        }
+    }
+
+    fun deleteOrderItem(id: Long) {
+        if (orderItemRepository.existsById(id)) {
+            orderItemRepository.deleteById(id)
+        } else {
+            throw NoSuchElementException("OrderItem with id $id not found")
+        }
+    }
+}

--- a/src/main/kotlin/com/nickdferrara/retailstore/orders/service/OrderService.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/orders/service/OrderService.kt
@@ -6,20 +6,23 @@ import org.springframework.stereotype.Service
 import java.util.*
 
 @Service
-class OrderService(private val orderRepository: OrderRepository) {
+class OrderService(
+    private val orderRepository: OrderRepository,
+    private val orderItemService: OrderItemService // Inject OrderItemService
+) {
 
     fun findAllOrders(): List<Order> = orderRepository.findAll()
 
     fun findOrderById(id: Long): Order? = orderRepository.findById(id).orElse(null)
 
     fun createOrder(order: Order): Order {
-        order.orderItems.forEach { it.order = order }
+        order.orderItems.forEach { orderItemService.createOrderItem(it) } // Use OrderItemService to save order items
         return orderRepository.save(order)
     }
 
     fun updateOrder(id: Long, order: Order): Order {
         return if (orderRepository.existsById(id)) {
-            order.orderItems.forEach { it.order = order }
+            order.orderItems.forEach { orderItemService.updateOrderItem(it.id, it) } // Use OrderItemService to save order items
             orderRepository.save(order.copy(id = id))
         } else {
             throw NoSuchElementException("Order with id $id not found")

--- a/src/test/kotlin/com/nickdferrara/retailstore/orders/OrderServiceTests.kt
+++ b/src/test/kotlin/com/nickdferrara/retailstore/orders/OrderServiceTests.kt
@@ -1,8 +1,10 @@
 package com.nickdferrara.retailstore.orders
 
 import com.nickdferrara.retailstore.orders.domain.Order
+import com.nickdferrara.retailstore.orders.domain.OrderItem
 import com.nickdferrara.retailstore.orders.repository.OrderRepository
 import com.nickdferrara.retailstore.orders.service.OrderService
+import com.nickdferrara.retailstore.orders.service.OrderItemService
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
@@ -15,13 +17,14 @@ import java.util.*
 class OrderServiceTests {
 
     private val orderRepository: OrderRepository = mock(OrderRepository::class.java)
-    private val orderService: OrderService = OrderService(orderRepository)
+    private val orderItemService: OrderItemService = mock(OrderItemService::class.java)
+    private val orderService: OrderService = OrderService(orderRepository, orderItemService)
 
     @Test
     fun `test findAllOrders`() {
         val orders = listOf(
-            Order(1, "ORD001", LocalDate.now(), "NEW", BigDecimal(100)),
-            Order(2, "ORD002", LocalDate.now(), "SHIPPED", BigDecimal(200))
+            Order(1, "ORD001", LocalDate.now(), "NEW", BigDecimal(100), emptyList()),
+            Order(2, "ORD002", LocalDate.now(), "SHIPPED", BigDecimal(200), emptyList())
         )
         `when`(orderRepository.findAll()).thenReturn(orders)
 
@@ -33,7 +36,7 @@ class OrderServiceTests {
 
     @Test
     fun `test findOrderById`() {
-        val order = Order(1, "ORD001", LocalDate.now(), "NEW", BigDecimal(100))
+        val order = Order(1, "ORD001", LocalDate.now(), "NEW", BigDecimal(100), emptyList())
         `when`(orderRepository.findById(1)).thenReturn(Optional.of(order))
 
         val result = orderService.findOrderById(1)
@@ -43,23 +46,33 @@ class OrderServiceTests {
 
     @Test
     fun `test createOrder`() {
-        val order = Order(1, "ORD001", LocalDate.now(), "NEW", BigDecimal(100))
+        val orderItems = listOf(
+            OrderItem(1, "Item1", "Brand1", 1, BigDecimal(10)),
+            OrderItem(2, "Item2", "Brand2", 2, BigDecimal(20))
+        )
+        val order = Order(1, "ORD001", LocalDate.now(), "NEW", BigDecimal(100), orderItems)
         `when`(orderRepository.save(order)).thenReturn(order)
 
         val result = orderService.createOrder(order)
         assertNotNull(result)
         assertEquals("ORD001", result.orderNumber)
+        verify(orderItemService, times(2)).createOrderItem(any(OrderItem::class.java))
     }
 
     @Test
     fun `test updateOrder`() {
-        val order = Order(1, "ORD001", LocalDate.now(), "NEW", BigDecimal(100))
+        val orderItems = listOf(
+            OrderItem(1, "Item1", "Brand1", 1, BigDecimal(10)),
+            OrderItem(2, "Item2", "Brand2", 2, BigDecimal(20))
+        )
+        val order = Order(1, "ORD001", LocalDate.now(), "NEW", BigDecimal(100), orderItems)
         `when`(orderRepository.existsById(1)).thenReturn(true)
         `when`(orderRepository.save(order)).thenReturn(order)
 
         val result = orderService.updateOrder(1, order)
         assertNotNull(result)
         assertEquals("ORD001", result.orderNumber)
+        verify(orderItemService, times(2)).updateOrderItem(anyLong(), any(OrderItem::class.java))
     }
 
     @Test


### PR DESCRIPTION
Add `OrderItemService` to handle CRUD operations for `OrderItem` entities and update `OrderService` to use this new service.

* **OrderItemService.kt**
  - Create `OrderItemService` class.
  - Inject `OrderItemRepository` into the service.
  - Implement basic CRUD methods: `findAllOrderItems`, `findOrderItemById`, `createOrderItem`, `updateOrderItem`, and `deleteOrderItem`.

* **OrderService.kt**
  - Inject `OrderItemService` into `OrderService`.
  - Update `createOrder` method to use `OrderItemService` to save order items.
  - Update `updateOrder` method to use `OrderItemService` to save order items.

* **OrderServiceTests.kt**
  - Mock `OrderItemService` in the test class.
  - Update tests for `createOrder` and `updateOrder` methods to verify interactions with `OrderItemService`.
  - Adjust test data to include `OrderItem` entities.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nickdferrara/Server-Springboot-Retail?shareId=3089ef50-a9d5-49f0-9fe4-b61dd8ac1780).