### PR TITLE
Add OrderRequest DTO and validation to orders module

### DIFF
--- a/src/main/kotlin/com/nickdferrara/retailstore/orders/dto/OrderItemRequest.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/orders/dto/OrderItemRequest.kt
@@ -1,0 +1,22 @@
+package com.nickdferrara.retailstore.orders.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+
+data class OrderItemRequest(
+    @field:NotBlank
+    val name: String,
+
+    @field:NotBlank
+    val brand: String,
+
+    @field:NotNull
+    @field:Positive
+    val quantity: Int,
+
+    @field:NotNull
+    @field:Positive
+    val price: BigDecimal
+)

--- a/src/main/kotlin/com/nickdferrara/retailstore/orders/dto/OrderRequest.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/orders/dto/OrderRequest.kt
@@ -1,0 +1,25 @@
+package com.nickdferrara.retailstore.orders.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class OrderRequest(
+    @field:NotBlank
+    val orderNumber: String,
+
+    @field:NotNull
+    val orderDate: LocalDate,
+
+    @field:NotBlank
+    val status: String,
+
+    @field:NotNull
+    @field:Positive
+    val totalAmount: BigDecimal,
+
+    @field:NotNull
+    val orderItems: List<OrderItemRequest>
+)

--- a/src/main/kotlin/com/nickdferrara/retailstore/orders/service/OrderService.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/orders/service/OrderService.kt
@@ -1,6 +1,8 @@
 package com.nickdferrara.retailstore.orders.service
 
 import com.nickdferrara.retailstore.orders.domain.Order
+import com.nickdferrara.retailstore.orders.domain.OrderItem
+import com.nickdferrara.retailstore.orders.dto.OrderRequest
 import com.nickdferrara.retailstore.orders.repository.OrderRepository
 import org.springframework.stereotype.Service
 import java.util.*
@@ -35,5 +37,23 @@ class OrderService(
         } else {
             throw NoSuchElementException("Order with id $id not found")
         }
+    }
+
+    fun convertToOrder(orderRequest: OrderRequest): Order {
+        val orderItems = orderRequest.orderItems.map { 
+            OrderItem(
+                name = it.name,
+                brand = it.brand,
+                quantity = it.quantity,
+                price = it.price
+            )
+        }
+        return Order(
+            orderNumber = orderRequest.orderNumber,
+            orderDate = orderRequest.orderDate,
+            status = orderRequest.status,
+            totalAmount = orderRequest.totalAmount,
+            orderItems = orderItems
+        )
     }
 }

--- a/src/main/kotlin/com/nickdferrara/retailstore/orders/web/OrderController.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/orders/web/OrderController.kt
@@ -1,7 +1,8 @@
 package com.nickdferrara.retailstore.orders.web
 
-import com.nickdferrara.retailstore.orders.domain.Order
+import com.nickdferrara.retailstore.orders.dto.OrderRequest
 import com.nickdferrara.retailstore.orders.service.OrderService
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -25,11 +26,15 @@ class OrderController(private val orderService: OrderService) {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    fun createOrder(@RequestBody order: Order): Order = orderService.createOrder(order)
+    fun createOrder(@Valid @RequestBody orderRequest: OrderRequest): Order {
+        val order = orderService.convertToOrder(orderRequest)
+        return orderService.createOrder(order)
+    }
 
     @PutMapping("/{id}")
-    fun updateOrder(@PathVariable id: Long, @RequestBody order: Order): ResponseEntity<Order> {
+    fun updateOrder(@PathVariable id: Long, @Valid @RequestBody orderRequest: OrderRequest): ResponseEntity<Order> {
         return try {
+            val order = orderService.convertToOrder(orderRequest)
             ResponseEntity.ok(orderService.updateOrder(id, order))
         } catch (e: NoSuchElementException) {
             ResponseEntity.notFound().build()


### PR DESCRIPTION
Add `OrderRequest` and `OrderItemRequest` DTOs and update `OrderController` and `OrderService` to use them.

* **OrderRequest DTO**
  - Create `OrderRequest` data class with properties `orderNumber`, `orderDate`, `status`, `totalAmount`, and `orderItems`.
  - Add validation annotations to the required fields in `OrderRequest`.

* **OrderItemRequest DTO**
  - Create `OrderItemRequest` data class with properties `name`, `brand`, `quantity`, and `price`.
  - Add validation annotations to the required fields in `OrderItemRequest`.

* **OrderController**
  - Update `createOrder` method to accept `OrderRequest` instead of `Order`.
  - Update `updateOrder` method to accept `OrderRequest` instead of `Order`.
  - Add validation to the `OrderRequest` parameter in `createOrder` and `updateOrder` methods.

* **OrderService**
  - Add `convertToOrder` method to convert `OrderRequest` to `Order`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nickdferrara/Server-Springboot-Retail?shareId=f644c9ff-d97b-477d-b585-73f124fe7a1b).