### PR TITLE
Update Orders module to use OrderStatus enum

### DIFF
--- a/src/main/kotlin/com/nickdferrara/retailstore/orders/domain/Order.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/orders/domain/Order.kt
@@ -11,10 +11,20 @@ data class Order(
     val id: Long = 0,
     val orderNumber: String,
     val orderDate: LocalDate,
-    val status: String,
+    @Enumerated(EnumType.STRING)
+    val status: OrderStatus,
     val totalAmount: BigDecimal,
 
     @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true)
     @JoinColumn(name = "order_id")
     val orderItems: List<OrderItem>
 )
+
+enum class OrderStatus {
+    PENDING,
+    CONFIRMED,
+    FULFILLED,
+    SHOPPED,
+    RETURNED,
+    COMPLETED
+}

--- a/src/main/kotlin/com/nickdferrara/retailstore/orders/dto/OrderRequest.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/orders/dto/OrderRequest.kt
@@ -1,5 +1,6 @@
 package com.nickdferrara.retailstore.orders.dto
 
+import com.nickdferrara.retailstore.orders.domain.OrderStatus
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Positive
@@ -13,8 +14,8 @@ data class OrderRequest(
     @field:NotNull
     val orderDate: LocalDate,
 
-    @field:NotBlank
-    val status: String,
+    @field:NotNull
+    val status: OrderStatus,
 
     @field:NotNull
     @field:Positive

--- a/src/main/kotlin/com/nickdferrara/retailstore/orders/service/OrderService.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/orders/service/OrderService.kt
@@ -2,6 +2,7 @@ package com.nickdferrara.retailstore.orders.service
 
 import com.nickdferrara.retailstore.orders.domain.Order
 import com.nickdferrara.retailstore.orders.domain.OrderItem
+import com.nickdferrara.retailstore.orders.domain.OrderStatus
 import com.nickdferrara.retailstore.orders.dto.OrderRequest
 import com.nickdferrara.retailstore.orders.repository.OrderRepository
 import org.springframework.stereotype.Service
@@ -19,6 +20,7 @@ class OrderService(
 
     fun createOrder(order: Order): Order {
         order.orderItems.forEach { orderItemService.createOrderItem(it) } // Use OrderItemService to save order items
+        order.status = OrderStatus.PENDING // Set status to PENDING when creating a new order
         return orderRepository.save(order)
     }
 

--- a/src/test/kotlin/com/nickdferrara/retailstore/orders/OrderServiceTests.kt
+++ b/src/test/kotlin/com/nickdferrara/retailstore/orders/OrderServiceTests.kt
@@ -2,6 +2,7 @@ package com.nickdferrara.retailstore.orders
 
 import com.nickdferrara.retailstore.orders.domain.Order
 import com.nickdferrara.retailstore.orders.domain.OrderItem
+import com.nickdferrara.retailstore.orders.domain.OrderStatus
 import com.nickdferrara.retailstore.orders.repository.OrderRepository
 import com.nickdferrara.retailstore.orders.service.OrderService
 import com.nickdferrara.retailstore.orders.service.OrderItemService
@@ -23,8 +24,8 @@ class OrderServiceTests {
     @Test
     fun `test findAllOrders`() {
         val orders = listOf(
-            Order(1, "ORD001", LocalDate.now(), "NEW", BigDecimal(100), emptyList()),
-            Order(2, "ORD002", LocalDate.now(), "SHIPPED", BigDecimal(200), emptyList())
+            Order(1, "ORD001", LocalDate.now(), OrderStatus.PENDING, BigDecimal(100), emptyList()),
+            Order(2, "ORD002", LocalDate.now(), OrderStatus.SHOPPED, BigDecimal(200), emptyList())
         )
         `when`(orderRepository.findAll()).thenReturn(orders)
 
@@ -36,7 +37,7 @@ class OrderServiceTests {
 
     @Test
     fun `test findOrderById`() {
-        val order = Order(1, "ORD001", LocalDate.now(), "NEW", BigDecimal(100), emptyList())
+        val order = Order(1, "ORD001", LocalDate.now(), OrderStatus.PENDING, BigDecimal(100), emptyList())
         `when`(orderRepository.findById(1)).thenReturn(Optional.of(order))
 
         val result = orderService.findOrderById(1)
@@ -50,12 +51,13 @@ class OrderServiceTests {
             OrderItem(1, "Item1", "Brand1", 1, BigDecimal(10)),
             OrderItem(2, "Item2", "Brand2", 2, BigDecimal(20))
         )
-        val order = Order(1, "ORD001", LocalDate.now(), "NEW", BigDecimal(100), orderItems)
+        val order = Order(1, "ORD001", LocalDate.now(), OrderStatus.PENDING, BigDecimal(100), orderItems)
         `when`(orderRepository.save(order)).thenReturn(order)
 
         val result = orderService.createOrder(order)
         assertNotNull(result)
         assertEquals("ORD001", result.orderNumber)
+        assertEquals(OrderStatus.PENDING, result.status)
         verify(orderItemService, times(2)).createOrderItem(any(OrderItem::class.java))
     }
 
@@ -65,7 +67,7 @@ class OrderServiceTests {
             OrderItem(1, "Item1", "Brand1", 1, BigDecimal(10)),
             OrderItem(2, "Item2", "Brand2", 2, BigDecimal(20))
         )
-        val order = Order(1, "ORD001", LocalDate.now(), "NEW", BigDecimal(100), orderItems)
+        val order = Order(1, "ORD001", LocalDate.now(), OrderStatus.PENDING, BigDecimal(100), orderItems)
         `when`(orderRepository.existsById(1)).thenReturn(true)
         `when`(orderRepository.save(order)).thenReturn(order)
 
@@ -82,5 +84,19 @@ class OrderServiceTests {
 
         orderService.deleteOrder(1)
         verify(orderRepository, times(1)).deleteById(1)
+    }
+
+    @Test
+    fun `test createOrder sets status to PENDING`() {
+        val orderItems = listOf(
+            OrderItem(1, "Item1", "Brand1", 1, BigDecimal(10)),
+            OrderItem(2, "Item2", "Brand2", 2, BigDecimal(20))
+        )
+        val order = Order(1, "ORD001", LocalDate.now(), OrderStatus.PENDING, BigDecimal(100), orderItems)
+        `when`(orderRepository.save(order)).thenReturn(order)
+
+        val result = orderService.createOrder(order)
+        assertNotNull(result)
+        assertEquals(OrderStatus.PENDING, result.status)
     }
 }


### PR DESCRIPTION
Update the Orders module to use an enum for order status and set the initial status to "Pending".

* **Order Domain**: Change the `status` field type from `String` to `OrderStatus` enum and add `@Enumerated(EnumType.STRING)` annotation.
* **OrderRequest DTO**: Change the `status` field type from `String` to `OrderStatus` enum.
* **OrderService**: Set the `status` field to `OrderStatus.PENDING` when creating a new order.
* **OrderServiceTests**: Update tests to use `OrderStatus` enum instead of `String` for the `status` field and add a test to verify that the `status` field is set to `OrderStatus.PENDING` when creating a new order.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nickdferrara/Server-Springboot-Retail?shareId=adf92a93-ebcd-4ef9-8a5c-8f1e46075ff5).