### PR TITLE
Update fulfillment status to use enum

### DIFF
--- a/src/main/kotlin/com/nickdferrara/retailstore/fulfillment/domain/Fulfillment.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/fulfillment/domain/Fulfillment.kt
@@ -10,5 +10,12 @@ data class Fulfillment(
     val id: Long = 0,
     val orderId: Long,
     val fulfillmentDate: LocalDate,
-    val status: String
+    @Enumerated(EnumType.STRING)
+    val status: FulfillmentStatus
 )
+
+enum class FulfillmentStatus {
+    PENDING,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/kotlin/com/nickdferrara/retailstore/fulfillment/service/FulfillmentService.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/fulfillment/service/FulfillmentService.kt
@@ -1,9 +1,11 @@
 package com.nickdferrara.retailstore.fulfillment.service
 
 import com.nickdferrara.retailstore.fulfillment.domain.Fulfillment
+import com.nickdferrara.retailstore.fulfillment.domain.FulfillmentStatus
 import com.nickdferrara.retailstore.fulfillment.repository.FulfillmentRepository
 import com.nickdferrara.retailstore.orders.domain.Order
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import java.util.*
 
 @Service
@@ -35,7 +37,7 @@ class FulfillmentService(private val fulfillmentRepository: FulfillmentRepositor
         val fulfillment = Fulfillment(
             orderId = order.id,
             fulfillmentDate = LocalDate.now(),
-            status = "CREATED"
+            status = FulfillmentStatus.PENDING
         )
         return fulfillmentRepository.save(fulfillment)
     }

--- a/src/test/kotlin/com/nickdferrara/retailstore/fulfillment/FulfillmentServiceTests.kt
+++ b/src/test/kotlin/com/nickdferrara/retailstore/fulfillment/FulfillmentServiceTests.kt
@@ -1,6 +1,7 @@
 package com.nickdferrara.retailstore.fulfillment
 
 import com.nickdferrara.retailstore.fulfillment.domain.Fulfillment
+import com.nickdferrara.retailstore.fulfillment.domain.FulfillmentStatus
 import com.nickdferrara.retailstore.fulfillment.repository.FulfillmentRepository
 import com.nickdferrara.retailstore.fulfillment.service.FulfillmentService
 import org.junit.jupiter.api.Assertions.*
@@ -19,8 +20,8 @@ class FulfillmentServiceTests {
     @Test
     fun `test findAllFulfillments`() {
         val fulfillments = listOf(
-            Fulfillment(1, 101, LocalDate.now(), "PENDING"),
-            Fulfillment(2, 102, LocalDate.now(), "COMPLETED")
+            Fulfillment(1, 101, LocalDate.now(), FulfillmentStatus.PENDING),
+            Fulfillment(2, 102, LocalDate.now(), FulfillmentStatus.COMPLETED)
         )
         `when`(fulfillmentRepository.findAll()).thenReturn(fulfillments)
 
@@ -32,7 +33,7 @@ class FulfillmentServiceTests {
 
     @Test
     fun `test findFulfillmentById`() {
-        val fulfillment = Fulfillment(1, 101, LocalDate.now(), "PENDING")
+        val fulfillment = Fulfillment(1, 101, LocalDate.now(), FulfillmentStatus.PENDING)
         `when`(fulfillmentRepository.findById(1)).thenReturn(Optional.of(fulfillment))
 
         val result = fulfillmentService.findFulfillmentById(1)
@@ -42,7 +43,7 @@ class FulfillmentServiceTests {
 
     @Test
     fun `test createFulfillment`() {
-        val fulfillment = Fulfillment(1, 101, LocalDate.now(), "PENDING")
+        val fulfillment = Fulfillment(1, 101, LocalDate.now(), FulfillmentStatus.PENDING)
         `when`(fulfillmentRepository.save(fulfillment)).thenReturn(fulfillment)
 
         val result = fulfillmentService.createFulfillment(fulfillment)
@@ -52,7 +53,7 @@ class FulfillmentServiceTests {
 
     @Test
     fun `test updateFulfillment`() {
-        val fulfillment = Fulfillment(1, 101, LocalDate.now(), "PENDING")
+        val fulfillment = Fulfillment(1, 101, LocalDate.now(), FulfillmentStatus.PENDING)
         `when`(fulfillmentRepository.existsById(1)).thenReturn(true)
         `when`(fulfillmentRepository.save(fulfillment)).thenReturn(fulfillment)
 


### PR DESCRIPTION
Update the fulfillment entity to use an enum for status.

* Change the `status` field type from `String` to `FulfillmentStatus` enum in `Fulfillment.kt`
* Add the `FulfillmentStatus` enum with values `PENDING`, `IN_PROGRESS`, and `COMPLETED` in `Fulfillment.kt`
* Update the `createFulfillmentFromOrder` method to use `FulfillmentStatus.PENDING` instead of `"CREATED"` in `FulfillmentService.kt`
* Update the test data to use `FulfillmentStatus` enum values instead of strings in `FulfillmentServiceTests.kt`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nickdferrara/Server-Springboot-Retail?shareId=b107facb-4e2e-4e73-9bd8-77684a909149).