### PR TITLE
Add mappers for PickList and PickListItem

### DIFF
--- a/src/main/kotlin/com/nickdferrara/retailstore/fulfillment/mapper/PickListItemMapper.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/fulfillment/mapper/PickListItemMapper.kt
@@ -1,0 +1,13 @@
+package com.nickdferrara.retailstore.fulfillment.mapper
+
+import com.nickdferrara.retailstore.fulfillment.domain.PickListItem
+import com.nickdferrara.retailstore.orders.domain.OrderItem
+import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+
+@Mapper(componentModel = "spring")
+interface PickListItemMapper {
+
+    @Mapping(target = "id", ignore = true)
+    fun toPickListItem(orderItem: OrderItem): PickListItem
+}

--- a/src/main/kotlin/com/nickdferrara/retailstore/fulfillment/mapper/PickListMapper.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/fulfillment/mapper/PickListMapper.kt
@@ -1,0 +1,13 @@
+package com.nickdferrara.retailstore.fulfillment.mapper
+
+import com.nickdferrara.retailstore.fulfillment.domain.PickList
+import com.nickdferrara.retailstore.orders.domain.Order
+import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+
+@Mapper(componentModel = "spring", uses = [PickListItemMapper::class])
+interface PickListMapper {
+
+    @Mapping(target = "id", ignore = true)
+    fun toPickList(order: Order): PickList
+}

--- a/src/main/kotlin/com/nickdferrara/retailstore/fulfillment/service/PickListService.kt
+++ b/src/main/kotlin/com/nickdferrara/retailstore/fulfillment/service/PickListService.kt
@@ -5,6 +5,8 @@ import com.nickdferrara.retailstore.fulfillment.domain.PickListItem
 import com.nickdferrara.retailstore.fulfillment.domain.PickListStatus
 import com.nickdferrara.retailstore.fulfillment.repository.PickListRepository
 import com.nickdferrara.retailstore.fulfillment.repository.PickListItemRepository
+import com.nickdferrara.retailstore.fulfillment.mapper.PickListMapper
+import com.nickdferrara.retailstore.fulfillment.mapper.PickListItemMapper
 import com.nickdferrara.retailstore.orders.domain.Order
 import org.springframework.stereotype.Service
 import java.util.*
@@ -12,7 +14,9 @@ import java.util.*
 @Service
 class PickListService(
     private val pickListRepository: PickListRepository,
-    private val pickListItemRepository: PickListItemRepository
+    private val pickListItemRepository: PickListItemRepository,
+    private val pickListMapper: PickListMapper,
+    private val pickListItemMapper: PickListItemMapper
 ) {
 
     fun findAllPickLists(): List<PickList> = pickListRepository.findAll()
@@ -39,17 +43,10 @@ class PickListService(
 
     fun createPickListFromOrder(order: Order): PickList {
         val pickListItems = order.orderItems.map { orderItem ->
-            PickListItem(
-                pickListId = 0,
-                name = orderItem.name,
-                brand = orderItem.brand,
-                quantity = orderItem.quantity,
-                price = orderItem.price
-            )
+            pickListItemMapper.toPickListItem(orderItem)
         }
 
-        val pickList = PickList(
-            orderId = order.id,
+        val pickList = pickListMapper.toPickList(order).copy(
             status = PickListStatus.PENDING,
             pickListItems = pickListItems
         )


### PR DESCRIPTION
Add mappers for PickList and PickListItem to the fulfillment module.

* **PickListMapper.kt**
  - Create a new mapper interface `PickListMapper` using MapStruct.
  - Add a method `toPickList` that maps an `Order` to a `PickList`.
  - Annotate the interface with `@Mapper(componentModel = "spring", uses = [PickListItemMapper::class])`.

* **PickListItemMapper.kt**
  - Create a new mapper interface `PickListItemMapper` using MapStruct.
  - Add a method `toPickListItem` that maps an `OrderItem` to a `PickListItem`.
  - Annotate the interface with `@Mapper(componentModel = "spring")`.

* **PickListService.kt**
  - Inject `PickListMapper` and `PickListItemMapper` into the `PickListService` class.
  - Update the `createPickListFromOrder` method to use `PickListMapper` and `PickListItemMapper`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nickdferrara/Server-Springboot-Retail?shareId=c610abc9-dbe6-4db6-9daf-c193d8353117).